### PR TITLE
db-expose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       MYSQL_DATABASE: ${KEYSTONE_DB_NAME:-keystone}
     volumes:
       - mysql:/var/lib/mysql
+    ports:
+      - "127.0.0.1:3307:3306"
 
   keystone:
     build:


### PR DESCRIPTION
I mapped container's 3306 to 127.0.0.1:3307 because sometime one can have local db instance running and that can conflict if you try to map 3306 to 3306. 

