### PR TITLE
Multiple Databases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,16 @@ services:
     image: mariadb:10.4.5-bionic
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MARKET_DB_PASSWORD: ${MARKET_DB_PASSWORD}
+      PROVIDER_DB_PASSWORD: ${PROVIDER_DB_PASSWORD}
       MYSQL_USER: ${KEYSTONE_DB_USER:-keystone}
       MYSQL_PASSWORD: ${KEYSTONE_DB_PASSWORD}
       MYSQL_DATABASE: ${KEYSTONE_DB_NAME:-keystone}
     volumes:
       - mysql:/var/lib/mysql
+      - ./tables/:/docker-entrypoint-initdb.d
     ports:
       - "127.0.0.1:${MARIADB_HOST_PORT:-3306}:3306"
-
   keystone:
     build:
       context: .

--- a/tables/00-set-passwords.sh
+++ b/tables/00-set-passwords.sh
@@ -1,0 +1,2 @@
+sed -i -e "s/MARKET_DB_PASSWORD/$MARKET_DB_PASSWORD/g" /docker-entrypoint-initdb.d/create_user_db.sql
+sed -i -e "s/PROVIDER_DB_PASSWORD/$PROVIDER_DB_PASSWORD/g" /docker-entrypoint-initdb.d/create_user_db.sql

--- a/tables/create_user_db.sql
+++ b/tables/create_user_db.sql
@@ -1,0 +1,5 @@
+CREATE DATABASE IF NOT EXISTS flocx_market;
+grant all privileges on flocx_market.* to 'flocx_market'@'localhost' identified by 'MARKET_DB_PASSWORD';
+CREATE DATABASE IF NOT EXISTS flocx_provider;
+grant all privileges on flocx_provider.* to 'flocx_provider'@'localhost' identified by 'PROVIDER_DB_PASSWORD';
+


### PR DESCRIPTION
I created a tables folder where you can add more users and databases in the tab.sql file and a.sh will replace the root database password as a password for these users. I name the script a.sh cuz these files will be executed in alphabetic order.