### PR TITLE
sed was unable to write in /docker-entrypoint.d directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       MYSQL_DATABASE: ${KEYSTONE_DB_NAME:-keystone}
     volumes:
       - mysql:/var/lib/mysql
-      - ./tables/:/docker-entrypoint-initdb.d
+      - ./entrypoint.d/:/docker-entrypoint-initdb.d
+      - ./sql:/sql
     ports:
       - "127.0.0.1:${MARIADB_HOST_PORT:-3306}:3306"
   keystone:

--- a/entrypoint.d/00-set-passwords.sh
+++ b/entrypoint.d/00-set-passwords.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+sed \
+	-e "s/MARKET_DB_PASSWORD/$MARKET_DB_PASSWORD/g" \
+	-e "s/PROVIDER_DB_PASSWORD/$PROVIDER_DB_PASSWORD/g" \
+	/sql/create_user_db.sql > /tmp/create_user_db.sql

--- a/entrypoint.d/10-create-users.sql
+++ b/entrypoint.d/10-create-users.sql
@@ -1,0 +1,1 @@
+source /tmp/create_user_db.sql

--- a/sql/create_user_db.sql
+++ b/sql/create_user_db.sql
@@ -1,0 +1,5 @@
+CREATE DATABASE IF NOT EXISTS flocx_market;
+GRANT ALL PRIVILEGES ON flocx_market.* TO 'flocx_market'@'%' IDENTIFIED BY 'MARKET_DB_PASSWORD';
+CREATE DATABASE IF NOT EXISTS flocx_provider;
+GRANT ALL PRIVILEGES ON flocx_provider.* TO 'flocx_provider'@'%' IDENTIFIED BY 'PROVIDER_DB_PASSWORD';
+

--- a/tables/00-set-passwords.sh
+++ b/tables/00-set-passwords.sh
@@ -1,2 +1,0 @@
-sed -i -e "s/MARKET_DB_PASSWORD/$MARKET_DB_PASSWORD/g" /docker-entrypoint-initdb.d/create_user_db.sql
-sed -i -e "s/PROVIDER_DB_PASSWORD/$PROVIDER_DB_PASSWORD/g" /docker-entrypoint-initdb.d/create_user_db.sql

--- a/tables/create_user_db.sql
+++ b/tables/create_user_db.sql
@@ -1,5 +1,0 @@
-CREATE DATABASE IF NOT EXISTS flocx_market;
-grant all privileges on flocx_market.* to 'flocx_market'@'localhost' identified by 'MARKET_DB_PASSWORD';
-CREATE DATABASE IF NOT EXISTS flocx_provider;
-grant all privileges on flocx_provider.* to 'flocx_provider'@'localhost' identified by 'PROVIDER_DB_PASSWORD';
-


### PR DESCRIPTION
in most cases, the `sed` command in the `00-set-passwords.sh` script
would be unable to write into the /docker-entrypoint.d directory
(this directory is bind-mounted from the host and generally won't have
appropriate permissions).  This commit writes the modified sql scripts
in `/tmp` and then reads them into sql scripts using the `source`
command.