### PR TITLE
Avoid permission problems when running database init scripts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       MYSQL_DATABASE: ${KEYSTONE_DB_NAME:-keystone}
     volumes:
       - mysql:/var/lib/mysql
-      - ./tables/:/docker-entrypoint-initdb.d
+      - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:z
     ports:
       - "127.0.0.1:${MARIADB_HOST_PORT:-3306}:3306"
   keystone:

--- a/docker-entrypoint-initdb.d/create-tables.sh
+++ b/docker-entrypoint-initdb.d/create-tables.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+mysql -u root -p${MYSQL_ROOT_PASSWORD} mysql <<EOF
+CREATE DATABASE IF NOT EXISTS flocx_market;
+GRANT ALL PRIVILEGES ON flocx_market.* TO 'flocx_market'@'localhost'
+	IDENTIFIED BY '${MARKET_DB_PASSWORD}';
+
+CREATE DATABASE IF NOT EXISTS flocx_provider;
+GRANT ALL PRIVILEGES ON flocx_provider.* TO 'flocx_provider'@'localhost'
+	IDENTIFIED BY '${PROVIDER_DB_PASSWORD}';
+EOF

--- a/tables/00-set-passwords.sh
+++ b/tables/00-set-passwords.sh
@@ -1,2 +1,0 @@
-sed -i -e "s/MARKET_DB_PASSWORD/$MARKET_DB_PASSWORD/g" /docker-entrypoint-initdb.d/create_user_db.sql
-sed -i -e "s/PROVIDER_DB_PASSWORD/$PROVIDER_DB_PASSWORD/g" /docker-entrypoint-initdb.d/create_user_db.sql

--- a/tables/create_user_db.sql
+++ b/tables/create_user_db.sql
@@ -1,5 +1,0 @@
-CREATE DATABASE IF NOT EXISTS flocx_market;
-grant all privileges on flocx_market.* to 'flocx_market'@'localhost' identified by 'MARKET_DB_PASSWORD';
-CREATE DATABASE IF NOT EXISTS flocx_provider;
-grant all privileges on flocx_provider.* to 'flocx_provider'@'localhost' identified by 'PROVIDER_DB_PASSWORD';
-


### PR DESCRIPTION
Rather than attempting to modify files in /docker-entrypoint-initdb.d,
just wrap a call to mysql in a shell script so that we can directly
use the necessary environment variables.

Closes #4