### PR TITLE
Create grant for wildcard host (%)

### DIFF
--- a/docker-entrypoint-initdb.d/create-tables.sh
+++ b/docker-entrypoint-initdb.d/create-tables.sh
@@ -4,8 +4,12 @@ mysql -u root -p${MYSQL_ROOT_PASSWORD} mysql <<EOF
 CREATE DATABASE IF NOT EXISTS flocx_market;
 GRANT ALL PRIVILEGES ON flocx_market.* TO 'flocx_market'@'localhost'
 	IDENTIFIED BY '${MARKET_DB_PASSWORD}';
+GRANT ALL PRIVILEGES ON flocx_market.* TO 'flocx_market'@'%'
+	IDENTIFIED BY '${MARKET_DB_PASSWORD}';
 
 CREATE DATABASE IF NOT EXISTS flocx_provider;
 GRANT ALL PRIVILEGES ON flocx_provider.* TO 'flocx_provider'@'localhost'
+	IDENTIFIED BY '${PROVIDER_DB_PASSWORD}';
+GRANT ALL PRIVILEGES ON flocx_provider.* TO 'flocx_provider'@'%'
 	IDENTIFIED BY '${PROVIDER_DB_PASSWORD}';
 EOF


### PR DESCRIPTION
Previously we were only creating a grant for users connecting from
`localhost`. This made it impossible to authenticate when connecting
from outside of the database container.

We now create grants for both `localhost` and `%`.